### PR TITLE
Typo `clear clc close all`

### DIFF
--- a/FVM_LaxWendroff.m
+++ b/FVM_LaxWendroff.m
@@ -1,6 +1,6 @@
-clear all;
-close all;
-clc;
+clear
+close all
+clc
 
 L=15;
 N=500; %% points in space


### PR DESCRIPTION
Like most of the people on this planet, you use `clear all` that does not exist in matlab. Please use `all` only for `close` :-D